### PR TITLE
Add support for pre-conditioned proposals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,3 +29,5 @@ Suggests:
 Config/testthat/edition: 3
 URL: https://github.com/UCL/rmcmc
 BugReports: https://github.com/UCL/rmcmc/issues
+Imports: 
+    Matrix

--- a/R/barker.R
+++ b/R/barker.R
@@ -2,7 +2,7 @@
 #'
 #' @param state Current chain state.
 #' @param target_distribution Target stationary distribution for chain. A list
-#'  with named entries `log_density` and `grad_log_density`corresponding to
+#'  with named entries `log_density` and `grad_log_density` corresponding to
 #'  respectively functions for evaluating the logarithm of the (potentially
 #'  unnormalized) density of the target distribution and its gradient.
 #'  As an alternative to `grad_log_density` an entry
@@ -10,8 +10,15 @@
 #'  returning both the value and gradient of the logarithm of the (unnormalized)
 #'  density of the target distribution as a list under the names `value` and
 #'  `grad` respectively.
-#' @param step_size Step size parameter of proposal distribution. A scalar value
-#'   determining scale of steps proposed.
+#' @param scale_and_shape Scalar, vector or matrix which scales and shapes
+#'  proposal distribution. If a scalar (in which case the value should be
+#'  non-negative) the auxiliary vector will be isotropically scaled by the
+#'  value. If a vector (in which case the value should be equal in length to the
+#'  dimension of the space and all entries non-negative) each dimension of the
+#'  auxiliary vector will be scaled separately. If a matrix (in which case the
+#'  value should be a square matrix with size equal to the dimension of the
+#'  space) then by pre-multiplying the auxiliary vector arbitrary linear
+#'  transformations can be performed.
 #' @param sample_auxiliary Function which generates a random vector from
 #'   auxiliary variable distribution.
 #' @param sample_uniform Function which generates a random vector from standard
@@ -26,25 +33,28 @@
 #'   log_density = function(x) sum(x^2) / 2,
 #'   grad_log_density = function(x) x
 #' )
-#' sample_barker(state, target_distribution, step_size = 1.)
+#' sample_barker(state, target_distribution, scale_and_shape = 1.)
 sample_barker <- function(
     state,
     target_distribution,
-    step_size,
+    scale_and_shape,
     sample_auxiliary = stats::rnorm,
     sample_uniform = stats::runif) {
   grad <- state$grad_log_density(target_distribution)
   dim <- state$dimension()
-  auxiliary <- step_size * sample_auxiliary(dim)
-  signs <- 2 * (sample_uniform(dim) < logistic_sigmoid(grad * auxiliary)) - 1
-  chain_state(state$position() + signs * auxiliary)
+  auxiliary <- sample_auxiliary(dim)
+  p_signs <- logistic_sigmoid(
+    Matrix::drop(Matrix::t(scale_and_shape) %*% grad) * auxiliary)
+  signs <- 2 * (sample_uniform(dim) < p_signs) - 1
+  momentum <- signs * auxiliary
+  position <- state$position() + Matrix::drop(scale_and_shape %*% momentum)
+  chain_state(position = position, momentum = momentum)
 }
 
 #' Compute logarithm of Barker proposal density ratio.
 #'
-#' @param state Current chain state.
+#' @inheritParams sample_barker
 #' @param proposed_state Proposed chain state.
-#' @param target_distribution Target stationary distribution for chain.
 #'
 #' @return Logarithm of proposal density ratio.
 #' @export
@@ -55,48 +65,70 @@ sample_barker <- function(
 #'   log_density = function(x) sum(x^2) / 2,
 #'   grad_log_density = function(x) x
 #' )
-#' proposed_state <- sample_barker(state, target_distribution, step_size = 1.)
+#' scale_and_shape <- 1.
+#' proposed_state <- sample_barker(state, target_distribution, scale_and_shape)
 #' log_density_ratio_barker(
-#'   state, proposed_state, target_distribution
+#'   state, proposed_state, target_distribution, scale_and_shape
 #' )
 log_density_ratio_barker <- function(
     state,
     proposed_state,
-    target_distribution) {
+    target_distribution,
+    scale_and_shape) {
   sum(
     log1p_exp(
-      (state$position() - proposed_state$position())
-      * state$grad_log_density(target_distribution)
+      state$momentum()
+      * (
+          Matrix::drop(Matrix::t(scale_and_shape))
+          * state$grad_log_density(target_distribution)
+        )
     ) - log1p_exp(
-      (proposed_state$position() - state$position())
-      * proposed_state$grad_log_density(target_distribution)
+      proposed_state$momentum()
+      * (
+          Matrix::drop(Matrix::t(scale_and_shape))
+          * proposed_state$grad_log_density(target_distribution)
+        )
     )
   )
 }
 
+is_non_scalar_vector <- function(obj) {
+  is.null(dim(obj)) && length(obj) > 1
+}
+
+get_shape_matrix <- function(scale, shape) {
+  shape <- if (is_non_scalar_vector(shape)) Matrix::Diagonal(x = shape) else shape
+  if (is.null(scale) && is.null(shape)) {
+    stop("One of scale and shape parameters must be set")
+  } else if (is.null(scale)) {
+    return(shape)
+  } else if (is.null(shape)) {
+    return(scale)
+  } else {
+    return(shape * scale)
+  }
+}
+
 #' Create a new Barker proposal object.
 #'
-#' @param target_distribution Target stationary distribution for chain. A list
-#'  with named entries `log_density` and `grad_log_density`corresponding to
-#'  respectively functions for evaluating the logarithm of the (potentially
-#'  unnormalized) density of the target distribution and its gradient.
-#'  As an alternative to `grad_log_density` an entry
-#'  `value_and_grad_log_density` may instead be provided which is a function
-#'  returning both the value and gradient of the logarithm of the (unnormalized)
-#'  density of the target distribution as a list under the names `value` and
-#'  `grad` respectively.
-#' @param step_size Step size parameter of proposal distribution. A scalar value
-#'   determining scale of steps proposed.
-#' @param sample_auxiliary Function which generates a random vector from
-#'   auxiliary variable distribution.
-#' @param sample_uniform Function which generates a random vector from standard
-#'   uniform distribution given an integer size.
+#' `barker_proposal` returns a list with function to sample from the proposal,
+#' evaluate the log density ratio for a state pair for the proposal and update
+#' the proposal parameters. The proposal has two parameters `scale` and `shape`.
+#' At least one of `scale` and `shape` must be set before sampling from the
+#' proposal or evaluating the log density ratio.
+#'
+#' @inheritParams sample_barker
+#' @param scale Scale parameter of proposal distribution. A non-negative scalar
+#'   value determining scale of steps proposed.
+#' @param shape Shape parameter of proposal distribution. Either a vector
+#'    corresponding to a diagonal shape matrix with per-dimension scaling
+#'    factors, or a matrix allowing arbitrary linear transformations.
 #'
 #' @return List with entries `sample`, a function to generate sample from
 #'   proposal distribution given current chain state, `log_density_ratio`, a
 #'   function to compute log density ratio for proposal for a given pair of
 #'   current and proposed chain states and `update`, a function to update
-#'   step size parameter of proposal.
+#'   parameters of proposal.
 #' @export
 #'
 #' @examples
@@ -104,23 +136,35 @@ log_density_ratio_barker <- function(
 #'   log_density = function(x) sum(x^2) / 2,
 #'   grad_log_density = function(x) x
 #' )
-#' proposal <- barker_proposal(target_distribution, step_size = 1.)
+#' proposal <- barker_proposal(target_distribution, scale = 1.)
 #' state <- chain_state(c(0., 0.))
 #' proposed_state <- proposal$sample(state)
 #' log_density_ratio <- proposal$log_density_ratio(state, proposed_state)
-#' proposal$update(step_size = 0.5)
+#' proposal$update(scale = 0.5)
 barker_proposal <- function(
     target_distribution,
-    step_size,
+    scale = NULL,
+    shape = NULL,
     sample_auxiliary = stats::rnorm,
     sample_uniform = stats::runif) {
   list(
-    sample = function(state) sample_barker(
-      state, target_distribution, step_size, sample_auxiliary, sample_uniform
-    ),
-    log_density_ratio = function(state, proposed_state) log_density_ratio_barker(
-      state, proposed_state, target_distribution
-    ),
-    update = function(step_size) step_size <<- step_size
+    sample = function(state) {
+      sample_barker(
+        state, target_distribution, get_shape_matrix(scale, shape), sample_auxiliary, sample_uniform
+      )
+    },
+    log_density_ratio = function(state, proposed_state) {
+      log_density_ratio_barker(
+        state, proposed_state, target_distribution, get_shape_matrix(scale, shape)
+      )
+    },
+    update = function(scale = NULL, shape = NULL) {
+      if (!is.null(scale)) {
+        scale <<- scale
+      }
+      if (!is.null(shape)) {
+        shape <<- shape
+      }
+    }
   )
 }

--- a/R/kernels.R
+++ b/R/kernels.R
@@ -17,7 +17,7 @@
 #'   log_density = function(x) sum(x^2) / 2,
 #'   grad_log_density = function(x) x
 #' )
-#' proposal <- barker_proposal(target_distribution, step_size = 1.)
+#' proposal <- barker_proposal(target_distribution, scale = 1.)
 #' n_sample <- 1000
 #' states <- vector("list", n_sample)
 #' states[[1]] <- chain_state(rnorm(2))

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,7 +44,7 @@ target_distribution <- list(
   log_density = function(x) -sum(x^2) / 2,
   grad_log_density = function(x) -x
 )
-proposal <- barker_proposal(target_distribution, step_size = 2.5)
+proposal <- barker_proposal(target_distribution, scale = 2.5)
 n_sample <- 1000
 dimension <- 2
 set.seed(876287L)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ target_distribution <- list(
   log_density = function(x) -sum(x^2) / 2,
   grad_log_density = function(x) -x
 )
-proposal <- barker_proposal(target_distribution, step_size = 2.5)
+proposal <- barker_proposal(target_distribution, scale = 2.5)
 n_sample <- 1000
 dimension <- 2
 set.seed(876287L)
@@ -56,5 +56,5 @@ for (s in 2:n_sample) {
 }
 mean_accept_prob <- sum_accept_prob / n_sample
 message(sprintf("Average acceptance probability is %.2f", mean_accept_prob))
-#> Average acceptance probability is 0.40
+#> Average acceptance probability is 0.38
 ```

--- a/man/barker_proposal.Rd
+++ b/man/barker_proposal.Rd
@@ -6,14 +6,15 @@
 \usage{
 barker_proposal(
   target_distribution,
-  step_size,
+  scale = NULL,
+  shape = NULL,
   sample_auxiliary = stats::rnorm,
   sample_uniform = stats::runif
 )
 }
 \arguments{
 \item{target_distribution}{Target stationary distribution for chain. A list
-with named entries \code{log_density} and \code{grad_log_density}corresponding to
+with named entries \code{log_density} and \code{grad_log_density} corresponding to
 respectively functions for evaluating the logarithm of the (potentially
 unnormalized) density of the target distribution and its gradient.
 As an alternative to \code{grad_log_density} an entry
@@ -22,8 +23,12 @@ returning both the value and gradient of the logarithm of the (unnormalized)
 density of the target distribution as a list under the names \code{value} and
 \code{grad} respectively.}
 
-\item{step_size}{Step size parameter of proposal distribution. A scalar value
-determining scale of steps proposed.}
+\item{scale}{Scale parameter of proposal distribution. A non-negative scalar
+value determining scale of steps proposed.}
+
+\item{shape}{Shape parameter of proposal distribution. Either a vector
+corresponding to a diagonal shape matrix with per-dimension scaling
+factors, or a matrix allowing arbitrary linear transformations.}
 
 \item{sample_auxiliary}{Function which generates a random vector from
 auxiliary variable distribution.}
@@ -36,19 +41,23 @@ List with entries \code{sample}, a function to generate sample from
 proposal distribution given current chain state, \code{log_density_ratio}, a
 function to compute log density ratio for proposal for a given pair of
 current and proposed chain states and \code{update}, a function to update
-step size parameter of proposal.
+parameters of proposal.
 }
 \description{
-Create a new Barker proposal object.
+\code{barker_proposal} returns a list with function to sample from the proposal,
+evaluate the log density ratio for a state pair for the proposal and update
+the proposal parameters. The proposal has two parameters \code{scale} and \code{shape}.
+At least one of \code{scale} and \code{shape} must be set before sampling from the
+proposal or evaluating the log density ratio.
 }
 \examples{
 target_distribution <- list(
   log_density = function(x) sum(x^2) / 2,
   grad_log_density = function(x) x
 )
-proposal <- barker_proposal(target_distribution, step_size = 1.)
+proposal <- barker_proposal(target_distribution, scale = 1.)
 state <- chain_state(c(0., 0.))
 proposed_state <- proposal$sample(state)
 log_density_ratio <- proposal$log_density_ratio(state, proposed_state)
-proposal$update(step_size = 0.5)
+proposal$update(scale = 0.5)
 }

--- a/man/log_density_ratio_barker.Rd
+++ b/man/log_density_ratio_barker.Rd
@@ -4,14 +4,37 @@
 \alias{log_density_ratio_barker}
 \title{Compute logarithm of Barker proposal density ratio.}
 \usage{
-log_density_ratio_barker(state, proposed_state, target_distribution)
+log_density_ratio_barker(
+  state,
+  proposed_state,
+  target_distribution,
+  scale_and_shape
+)
 }
 \arguments{
 \item{state}{Current chain state.}
 
 \item{proposed_state}{Proposed chain state.}
 
-\item{target_distribution}{Target stationary distribution for chain.}
+\item{target_distribution}{Target stationary distribution for chain. A list
+with named entries \code{log_density} and \code{grad_log_density} corresponding to
+respectively functions for evaluating the logarithm of the (potentially
+unnormalized) density of the target distribution and its gradient.
+As an alternative to \code{grad_log_density} an entry
+\code{value_and_grad_log_density} may instead be provided which is a function
+returning both the value and gradient of the logarithm of the (unnormalized)
+density of the target distribution as a list under the names \code{value} and
+\code{grad} respectively.}
+
+\item{scale_and_shape}{Scalar, vector or matrix which scales and shapes
+proposal distribution. If a scalar (in which case the value should be
+non-negative) the auxiliary vector will be isotropically scaled by the
+value. If a vector (in which case the value should be equal in length to the
+dimension of the space and all entries non-negative) each dimension of the
+auxiliary vector will be scaled separately. If a matrix (in which case the
+value should be a square matrix with size equal to the dimension of the
+space) then by pre-multiplying the auxiliary vector arbitrary linear
+transformations can be performed.}
 }
 \value{
 Logarithm of proposal density ratio.
@@ -25,8 +48,9 @@ target_distribution <- list(
   log_density = function(x) sum(x^2) / 2,
   grad_log_density = function(x) x
 )
-proposed_state <- sample_barker(state, target_distribution, step_size = 1.)
+scale_and_shape <- 1.
+proposed_state <- sample_barker(state, target_distribution, scale_and_shape)
 log_density_ratio_barker(
-  state, proposed_state, target_distribution
+  state, proposed_state, target_distribution, scale_and_shape
 )
 }

--- a/man/sample_barker.Rd
+++ b/man/sample_barker.Rd
@@ -7,7 +7,7 @@
 sample_barker(
   state,
   target_distribution,
-  step_size,
+  scale_and_shape,
   sample_auxiliary = stats::rnorm,
   sample_uniform = stats::runif
 )
@@ -16,7 +16,7 @@ sample_barker(
 \item{state}{Current chain state.}
 
 \item{target_distribution}{Target stationary distribution for chain. A list
-with named entries \code{log_density} and \code{grad_log_density}corresponding to
+with named entries \code{log_density} and \code{grad_log_density} corresponding to
 respectively functions for evaluating the logarithm of the (potentially
 unnormalized) density of the target distribution and its gradient.
 As an alternative to \code{grad_log_density} an entry
@@ -25,8 +25,15 @@ returning both the value and gradient of the logarithm of the (unnormalized)
 density of the target distribution as a list under the names \code{value} and
 \code{grad} respectively.}
 
-\item{step_size}{Step size parameter of proposal distribution. A scalar value
-determining scale of steps proposed.}
+\item{scale_and_shape}{Scalar, vector or matrix which scales and shapes
+proposal distribution. If a scalar (in which case the value should be
+non-negative) the auxiliary vector will be isotropically scaled by the
+value. If a vector (in which case the value should be equal in length to the
+dimension of the space and all entries non-negative) each dimension of the
+auxiliary vector will be scaled separately. If a matrix (in which case the
+value should be a square matrix with size equal to the dimension of the
+space) then by pre-multiplying the auxiliary vector arbitrary linear
+transformations can be performed.}
 
 \item{sample_auxiliary}{Function which generates a random vector from
 auxiliary variable distribution.}
@@ -46,5 +53,5 @@ target_distribution <- list(
   log_density = function(x) sum(x^2) / 2,
   grad_log_density = function(x) x
 )
-sample_barker(state, target_distribution, step_size = 1.)
+sample_barker(state, target_distribution, scale_and_shape = 1.)
 }

--- a/man/sample_metropolis_hastings.Rd
+++ b/man/sample_metropolis_hastings.Rd
@@ -35,7 +35,7 @@ target_distribution <- list(
   log_density = function(x) sum(x^2) / 2,
   grad_log_density = function(x) x
 )
-proposal <- barker_proposal(target_distribution, step_size = 1.)
+proposal <- barker_proposal(target_distribution, scale = 1.)
 n_sample <- 1000
 states <- vector("list", n_sample)
 states[[1]] <- chain_state(rnorm(2))

--- a/tests/testthat/test-barker.R
+++ b/tests/testthat/test-barker.R
@@ -1,15 +1,16 @@
-barker_proposal_with_standard_normal_target <- function(step_size) {
+barker_proposal_with_standard_normal_target <- function(
+    scale = NULL, shape = NULL) {
   target_distribution <- standard_normal_target_distribution()
-  barker_proposal(target_distribution, step_size = step_size)
+  barker_proposal(target_distribution, scale = scale, shape = shape)
 }
 
 for (dim in c(1, 2)) {
   test_that(
     sprintf(
-      "Proposal sampling with step_size = 0 doesn't change state (dim %i)", dim
+      "Proposal sampling with scale = 0 doesn't change state (dim %i)", dim
     ),
     {
-      proposal <- barker_proposal_with_standard_normal_target(step_size = 0)
+      proposal <- barker_proposal_with_standard_normal_target(scale = 0)
       withr::with_seed(seed = default_seed(), code <- {
         state <- chain_state(rnorm(dim))
         proposed_state <- proposal$sample(state)
@@ -17,14 +18,14 @@ for (dim in c(1, 2)) {
       expect_identical(proposed_state$position(), state$position())
     }
   )
-  for (step_size in c(0.5, 1.)) {
+  for (scale in c(0.5, 1.)) {
     test_that(
       sprintf(
-        "Proposal sampling generates valid state (dim %i, step_size %.1f)",
-        dim, step_size
+        "Proposal sampling generates valid state (dim %i, scale %.1f)",
+        dim, scale
       ),
       {
-        proposal <- barker_proposal_with_standard_normal_target(step_size)
+        proposal <- barker_proposal_with_standard_normal_target(scale)
         withr::with_seed(seed = default_seed(), code = {
           state <- chain_state(rnorm(dim))
           proposed_state <- proposal$sample(state)
@@ -35,11 +36,11 @@ for (dim in c(1, 2)) {
 
     test_that(
       sprintf(
-        "Proposal sampling doesn't change initial state (dim %i, step_size %.1f)",
-        dim, step_size
+        "Proposal sampling doesn't change initial state (dim %i, scale %.1f)",
+        dim, scale
       ),
       {
-        proposal <- barker_proposal_with_standard_normal_target(step_size)
+        proposal <- barker_proposal_with_standard_normal_target(scale)
         withr::with_seed(seed = default_seed(), code = {
           position <- rnorm(dim)
           state <- chain_state(position)
@@ -51,11 +52,11 @@ for (dim in c(1, 2)) {
 
     test_that(
       sprintf(
-        "Proposal sampling changes state (dim %i, step_size %.1f)",
-        dim, step_size
+        "Proposal sampling changes state (dim %i, scale %.1f)",
+        dim, scale
       ),
       {
-        proposal <- barker_proposal_with_standard_normal_target(step_size)
+        proposal <- barker_proposal_with_standard_normal_target(scale)
         withr::with_seed(seed = default_seed(), code = {
           state <- chain_state(rnorm(1))
           proposed_state <- proposal$sample(state)
@@ -66,11 +67,11 @@ for (dim in c(1, 2)) {
 
     test_that(
       sprintf(
-        "Proposal sampling with same seed gives same state (dim %i, step_size %.1f)",
-        dim, step_size
+        "Proposal sampling with same seed gives same state (dim %i, scale %.1f)",
+        dim, scale
       ),
       {
-        proposal <- barker_proposal_with_standard_normal_target(step_size)
+        proposal <- barker_proposal_with_standard_normal_target(scale)
         withr::with_seed(seed = default_seed(), code = {
           position <- rnorm(dim)
           state <- chain_state(position)
@@ -87,11 +88,11 @@ for (dim in c(1, 2)) {
 
     test_that(
       sprintf(
-        "Proposal sampling with different seed gives different state (dim %i, step_size %.1f)",
-        dim, step_size
+        "Proposal sampling with different seed gives different state (dim %i, scale %.1f)",
+        dim, scale
       ),
       {
-        proposal <- barker_proposal_with_standard_normal_target(step_size)
+        proposal <- barker_proposal_with_standard_normal_target(scale)
         withr::with_seed(seed = default_seed(), code = {
           state <- chain_state(rnorm(dim))
           proposed_state <- proposal$sample(state)
@@ -102,5 +103,58 @@ for (dim in c(1, 2)) {
         )
       }
     )
+  }
+}
+
+
+for (dim in c(1, 2)) {
+  for (scale in c(1., 2., 0.5)) {
+    for (case in c("matrix_shape_null_scale", "vector_shape_null_scale")) {
+      test_that(
+        sprintf(
+          paste0(
+            "Proposal sampling with scaled identity shape equivalent to just ",
+            "scale (dim %i, scale %.1f, %s)"
+          ),
+          dim, scale, case
+        ),
+        {
+          shape <- switch(case,
+            matrix_shape_null_scale = diag(scale, dim),
+            matrix_shape_with_scale = diag(dim),
+            vector_shape_null_scale = rep(scale, dim),
+            vector_shape_with_scale = rep(1, dim),
+            stop("Invalid case")
+          )
+          scale_for_use_with_shape <- switch(case,
+            matrix_shape_null_scale = ,
+            vector_shape_null_scale = NULL,
+            matrix_shape_with_scale = ,
+            vector_shape_with_scale = scale,
+            stop("Invalid case")
+          )
+          proposal_scale <- barker_proposal_with_standard_normal_target(scale)
+          proposal_scale_and_shape <- barker_proposal_with_standard_normal_target(
+            scale_for_use_with_shape, shape
+          )
+          withr::with_seed(seed = default_seed(), code = {
+            position <- rnorm(dim)
+            state <- chain_state(position)
+            withr::with_preserve_seed({
+              proposed_state_scale <- proposal_scale$sample(state)
+            })
+            proposed_state_scale_and_shape <- proposal_scale_and_shape$sample(state)
+          })
+          expect_identical(
+            proposed_state_scale$position(),
+            proposed_state_scale_and_shape$position()
+          )
+          expect_identical(
+            proposal_scale$log_density_ratio(state, proposed_state_scale),
+            proposal_scale_and_shape$log_density_ratio(state, proposed_state_scale_and_shape)
+          )
+        }
+      )
+    }
   }
 }


### PR DESCRIPTION
Adds support for using diagonal or dense preconditioners with Barker proposal. Proposal now accepts separate `scale` and `shape` parameters with latter able to be either a matrix or vector (the latter corresponding to a diagonal preconditioner).