### PR TITLE
Fixing hash key expression in pre-commit workflow cache step

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ '{{' }} hashFiles('.pre-commit-config.yaml') {{ '}}' }}
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Removes escaped `{{` from template