### PR TITLE
Improvements to `sample_chain` interface

### DIFF
--- a/R/adaptation.R
+++ b/R/adaptation.R
@@ -1,7 +1,5 @@
 #' Create object to adapt proposal scale to coerce average acceptance rate.
 #'
-#' @param proposal Proposal object to adapt. Must define an `update` function
-#'   which accepts a parameter `scale` for setting scale parameter of proposal.
 #' @param initial_scale Initial value to use for scale parameter. If not set
 #'   explicitly a proposal and dimension dependent default will be used.
 #' @param target_accept_prob Target value for average accept probability for
@@ -59,8 +57,6 @@ scale_adapter <- function(
 #' Create object to adapt proposal with per dimension scales based on estimates
 #' of target distribution variances.
 #'
-#' @param proposal Proposal object to adapt. Must define an `update` function
-#'   which accepts a parameter `shape` for setting shape parameter of proposal.
 #' @param kappa Decay rate exponent in `[0.5, 1]` for adaptation learning rate.
 #'
 #' @inherit scale_adapter return

--- a/R/adaptation.R
+++ b/R/adaptation.R
@@ -9,8 +9,8 @@
 #' @param kappa Decay rate exponent in `[0.5, 1]` for adaptation learning rate.
 #'
 #' @return List of functions with entries
-#' * `initialize`, a function for initializing adapter state at beginning of
-#'   chain,
+#' * `initialize`, a function for initializing adapter state and proposal
+#'   parameters at beginning of chain,
 #' * `update` a function for updating adapter state and proposal parameters on
 #'   each chain iteration,
 #' * `finalize` a function for performing any final updates to adapter state and
@@ -27,24 +27,22 @@
 #'   grad_log_density = function(x) -x
 #' )
 #' proposal <- barker_proposal(target_distribution)
-#' adapter <- scale_adapter(
-#'   proposal,
-#'   initial_scale = 1., target_accept_prob = 0.4
-#' )
+#' adapter <- scale_adapter(initial_scale = 1., target_accept_prob = 0.4)
+#' adapter$initialize(proposal, chain_state(c(0, 0)))
 scale_adapter <- function(
-    proposal, initial_scale = NULL, target_accept_prob = NULL, kappa = 0.6) {
+    initial_scale = NULL, target_accept_prob = NULL, kappa = 0.6) {
   log_scale <- NULL
-  if (is.null(target_accept_prob)) {
-    target_accept_prob <- proposal$default_target_accept_prob()
-  }
-  initialize <- function(initial_state) {
+  initialize <- function(proposal, initial_state) {
     if (is.null(initial_scale)) {
       initial_scale <- proposal$default_initial_scale(initial_state$dimension())
     }
     log_scale <<- log(initial_scale)
     proposal$update(scale = initial_scale)
   }
-  update <- function(sample_index, state_and_statistics) {
+  update <- function(proposal, sample_index, state_and_statistics) {
+    if (is.null(target_accept_prob)) {
+      target_accept_prob <- proposal$default_target_accept_prob()
+    }
     gamma <- sample_index^(-kappa)
     accept_prob <- state_and_statistics$statistics$accept_prob
     log_scale <<- log_scale + gamma * (accept_prob - target_accept_prob)
@@ -53,7 +51,7 @@ scale_adapter <- function(
   list(
     initialize = initialize,
     update = update,
-    finalize = function() {},
+    finalize = NULL,
     state = function() list(log_scale = log_scale)
   )
 }
@@ -74,15 +72,16 @@ scale_adapter <- function(
 #'   grad_log_density = function(x) -x
 #' )
 #' proposal <- barker_proposal(target_distribution)
-#' adapter <- variance_adapter(proposal)
-variance_adapter <- function(proposal, kappa = 0.6) {
+#' adapter <- variance_adapter()
+#' adapter$initialize(proposal, chain_state(c(0, 0)))
+variance_adapter <- function(kappa = 0.6) {
   mean_estimate <- NULL
   variance_estimate <- NULL
-  initialize <- function(initial_state) {
+  initialize <- function(proposal, initial_state) {
     mean_estimate <<- initial_state$position()
     variance_estimate <<- rep(1., initial_state$dimension())
   }
-  update <- function(sample_index, state_and_statistics) {
+  update <- function(proposal, sample_index, state_and_statistics) {
     gamma <- sample_index^(-kappa)
     position <- state_and_statistics$state$position()
     mean_estimate <<- mean_estimate + gamma * (position - mean_estimate)
@@ -124,20 +123,23 @@ variance_adapter <- function(proposal, kappa = 0.6) {
 #'   grad_log_density = function(x) -x
 #' )
 #' proposal <- barker_proposal(target_distribution)
-#' adapter <- robust_shape_adapter(
-#'   proposal,
-#'   initial_scale = 1.,
-#'   target_accept_prob = 0.4
-#' )
+#' adapter <- robust_shape_adapter(initial_scale = 1., target_accept_prob = 0.4)
+#' adapter$initialize(proposal, chain_state(c(0, 0)))
 robust_shape_adapter <- function(
-    proposal, initial_scale, target_accept_prob = 0.4, kappa = 0.6) {
+    initial_scale = NULL, target_accept_prob = NULL, kappa = 0.6) {
   rlang::check_installed("ramcmc", reason = "to use this function")
   shape <- NULL
-  initialize <- function(initial_state) {
+  initialize <- function(proposal, initial_state) {
+    if (is.null(initial_scale)) {
+      initial_scale <- proposal$default_initial_scale(initial_state$dimension())
+    }
     shape <<- initial_scale * diag(initial_state$dimension())
     proposal$update(shape = shape)
   }
-  update <- function(sample_index, state_and_statistics) {
+  update <- function(proposal, sample_index, state_and_statistics) {
+    if (is.null(target_accept_prob)) {
+      target_accept_prob <- proposal$default_target_accept_prob()
+    }
     momentum <- state_and_statistics$proposed_state$momentum()
     accept_prob <- state_and_statistics$statistics$accept_prob
     shape <<- ramcmc::adapt_S(

--- a/R/chains.R
+++ b/R/chains.R
@@ -163,7 +163,7 @@ chain_loop <- function(
     statistic_names) {
   progress_bar <- get_progress_bar(use_progress_bar, n_iteration, stage_name)
   for (adapter in adapters) {
-    adapter$initialize(state)
+    adapter$initialize(proposal, state)
   }
   if (record_traces_and_statistics) {
     trace_names <- names(unlist(trace_function(state)))
@@ -176,25 +176,25 @@ chain_loop <- function(
     traces <- NULL
     statistics <- NULL
   }
-  for (s in seq_len(n_iteration)) {
+  for (chain_iteration in seq_len(n_iteration)) {
     state_and_statistics <- sample_metropolis_hastings(
       state, target_distribution, proposal
     )
     for (adapter in adapters) {
-      adapter$update(s + 1, state_and_statistics)
+      adapter$update(proposal, chain_iteration + 1, state_and_statistics)
     }
     state <- state_and_statistics$state
     if (record_traces_and_statistics) {
-      traces[s, ] <- unlist(trace_function(state))
+      traces[chain_iteration, ] <- unlist(trace_function(state))
       adapter_states <- lapply(adapters, function(a) a$state())
-      statistics[s, ] <- unlist(
+      statistics[chain_iteration, ] <- unlist(
         c(state_and_statistics$statistics, adapter_states)
       )
     }
     if (!is.null(progress_bar)) progress_bar$tick()
   }
   for (adapter in adapters) {
-    if (!is.null(adapter$finalize)) adapter$finalize()
+    if (!is.null(adapter$finalize)) adapter$finalize(proposal)
   }
   list(final_state = state, traces = traces, statistics = statistics)
 }

--- a/R/chains.R
+++ b/R/chains.R
@@ -72,7 +72,7 @@ sample_chain <- function(
   if (is.vector(initial_state) && is.atomic(initial_state)) {
     state <- chain_state(initial_state)
   } else if (is.vector(initial_state) && "position" %in% names(initial_state)) {
-    state <- initial_state
+    state <- initial_state$copy()
   } else {
     stop("initial_state must be a vector or list with an entry named position.")
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ results <- sample_chain(
   initial_state = rnorm(dimension),
   n_warm_up_iteration = 1000,
   n_main_iteration = 1000,
-  adapters = list(scale_adapter(proposal), variance_adapter(proposal))
+  adapters = list(scale_adapter(), variance_adapter())
 )
 mean_accept_prob <- mean(results$statistics[, "accept_prob"])
 adapted_shape <- proposal$parameters()$shape

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ results <- sample_chain(
   initial_state = rnorm(dimension),
   n_warm_up_iteration = 1000,
   n_main_iteration = 1000,
-  adapters = list(scale_adapter(proposal), variance_adapter(proposal))
+  adapters = list(scale_adapter(), variance_adapter())
 )
 mean_accept_prob <- mean(results$statistics[, "accept_prob"])
 adapted_shape <- proposal$parameters()$shape

--- a/man/robust_shape_adapter.Rd
+++ b/man/robust_shape_adapter.Rd
@@ -6,16 +6,12 @@
 Metropolis algorithm of Vihola (2012).}
 \usage{
 robust_shape_adapter(
-  proposal,
-  initial_scale,
-  target_accept_prob = 0.4,
+  initial_scale = NULL,
+  target_accept_prob = NULL,
   kappa = 0.6
 )
 }
 \arguments{
-\item{proposal}{Proposal object to adapt. Must define an \code{update} function
-which accepts a parameter \code{scale} for setting scale parameter of proposal.}
-
 \item{initial_scale}{Initial value to use for scale parameter. If not set
 explicitly a proposal and dimension dependent default will be used.}
 
@@ -27,8 +23,8 @@ chain. If not set a proposal dependent default will be used.}
 \value{
 List of functions with entries
 \itemize{
-\item \code{initialize}, a function for initializing adapter state at beginning of
-chain,
+\item \code{initialize}, a function for initializing adapter state and proposal
+parameters at beginning of chain,
 \item \code{update} a function for updating adapter state and proposal parameters on
 each chain iteration,
 \item \code{finalize} a function for performing any final updates to adapter state and
@@ -47,11 +43,8 @@ target_distribution <- list(
   grad_log_density = function(x) -x
 )
 proposal <- barker_proposal(target_distribution)
-adapter <- robust_shape_adapter(
-  proposal,
-  initial_scale = 1.,
-  target_accept_prob = 0.4
-)
+adapter <- robust_shape_adapter(initial_scale = 1., target_accept_prob = 0.4)
+adapter$initialize(proposal, chain_state(c(0, 0)))
 }
 \references{
 Vihola, M. (2012). Robust adaptive Metropolis algorithm with

--- a/man/scale_adapter.Rd
+++ b/man/scale_adapter.Rd
@@ -14,9 +14,6 @@ explicitly a proposal and dimension dependent default will be used.}
 chain. If not set a proposal dependent default will be used.}
 
 \item{kappa}{Decay rate exponent in \verb{[0.5, 1]} for adaptation learning rate.}
-
-\item{proposal}{Proposal object to adapt. Must define an \code{update} function
-which accepts a parameter \code{scale} for setting scale parameter of proposal.}
 }
 \value{
 List of functions with entries

--- a/man/scale_adapter.Rd
+++ b/man/scale_adapter.Rd
@@ -4,17 +4,9 @@
 \alias{scale_adapter}
 \title{Create object to adapt proposal scale to coerce average acceptance rate.}
 \usage{
-scale_adapter(
-  proposal,
-  initial_scale = NULL,
-  target_accept_prob = NULL,
-  kappa = 0.6
-)
+scale_adapter(initial_scale = NULL, target_accept_prob = NULL, kappa = 0.6)
 }
 \arguments{
-\item{proposal}{Proposal object to adapt. Must define an \code{update} function
-which accepts a parameter \code{scale} for setting scale parameter of proposal.}
-
 \item{initial_scale}{Initial value to use for scale parameter. If not set
 explicitly a proposal and dimension dependent default will be used.}
 
@@ -22,12 +14,15 @@ explicitly a proposal and dimension dependent default will be used.}
 chain. If not set a proposal dependent default will be used.}
 
 \item{kappa}{Decay rate exponent in \verb{[0.5, 1]} for adaptation learning rate.}
+
+\item{proposal}{Proposal object to adapt. Must define an \code{update} function
+which accepts a parameter \code{scale} for setting scale parameter of proposal.}
 }
 \value{
 List of functions with entries
 \itemize{
-\item \code{initialize}, a function for initializing adapter state at beginning of
-chain,
+\item \code{initialize}, a function for initializing adapter state and proposal
+parameters at beginning of chain,
 \item \code{update} a function for updating adapter state and proposal parameters on
 each chain iteration,
 \item \code{finalize} a function for performing any final updates to adapter state and
@@ -46,8 +41,6 @@ target_distribution <- list(
   grad_log_density = function(x) -x
 )
 proposal <- barker_proposal(target_distribution)
-adapter <- scale_adapter(
-  proposal,
-  initial_scale = 1., target_accept_prob = 0.4
-)
+adapter <- scale_adapter(initial_scale = 1., target_accept_prob = 0.4)
+adapter$initialize(proposal, chain_state(c(0, 0)))
 }

--- a/man/variance_adapter.Rd
+++ b/man/variance_adapter.Rd
@@ -5,19 +5,19 @@
 \title{Create object to adapt proposal with per dimension scales based on estimates
 of target distribution variances.}
 \usage{
-variance_adapter(proposal, kappa = 0.6)
+variance_adapter(kappa = 0.6)
 }
 \arguments{
+\item{kappa}{Decay rate exponent in \verb{[0.5, 1]} for adaptation learning rate.}
+
 \item{proposal}{Proposal object to adapt. Must define an \code{update} function
 which accepts a parameter \code{shape} for setting shape parameter of proposal.}
-
-\item{kappa}{Decay rate exponent in \verb{[0.5, 1]} for adaptation learning rate.}
 }
 \value{
 List of functions with entries
 \itemize{
-\item \code{initialize}, a function for initializing adapter state at beginning of
-chain,
+\item \code{initialize}, a function for initializing adapter state and proposal
+parameters at beginning of chain,
 \item \code{update} a function for updating adapter state and proposal parameters on
 each chain iteration,
 \item \code{finalize} a function for performing any final updates to adapter state and
@@ -37,5 +37,6 @@ target_distribution <- list(
   grad_log_density = function(x) -x
 )
 proposal <- barker_proposal(target_distribution)
-adapter <- variance_adapter(proposal)
+adapter <- variance_adapter()
+adapter$initialize(proposal, chain_state(c(0, 0)))
 }

--- a/man/variance_adapter.Rd
+++ b/man/variance_adapter.Rd
@@ -9,9 +9,6 @@ variance_adapter(kappa = 0.6)
 }
 \arguments{
 \item{kappa}{Decay rate exponent in \verb{[0.5, 1]} for adaptation learning rate.}
-
-\item{proposal}{Proposal object to adapt. Must define an \code{update} function
-which accepts a parameter \code{shape} for setting shape parameter of proposal.}
 }
 \value{
 List of functions with entries

--- a/tests/testthat/test-adaptation.R
+++ b/tests/testthat/test-adaptation.R
@@ -253,3 +253,24 @@ for (dimension in c(1L, 2L, 5L)) {
     }
   )
 }
+
+test_that("sample_chain works with dummy adapter with required interface", {
+  dummy_adapter <- list(
+    initialize = function(proposal, initial_state) {},
+    update = function(proposal, sample_index, state_and_statistics) {},
+    finalize = function(proposal) {},
+    state = function() list()
+  )
+  target_distribution <- standard_normal_target_distribution()
+  proposal <- barker_proposal(target_distribution, scale = 1)
+  expect_no_error(
+    sample_chain(
+      target_distribution = target_distribution,
+      proposal = proposal,
+      initial_state = chain_state(0),
+      n_warm_up_iteration = 1,
+      n_main_iteration = 0,
+      adapters = list(dummy_adapter)
+    )
+  )
+})

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -23,9 +23,7 @@ for (n_warm_up_iteration in c(0, 1, 10)) {
                 target_distribution <- standard_normal_target_distribution()
                 barker_proposal(target_distribution)
                 proposal <- barker_proposal(target_distribution)
-                adapters <- list(
-                  scale_adapter(proposal, initial_scale = 1.)
-                )
+                adapters <- list(scale_adapter(initial_scale = 1.))
                 withr::with_seed(default_seed(), {
                   position <- rnorm(dimension)
                 })

--- a/vignettes/barker-proposal.Rmd
+++ b/vignettes/barker-proposal.Rmd
@@ -75,8 +75,8 @@ based on estimates on the coordinate-wise variances under the target distributio
 
 ```{r}
 adapters <- list(
-  scale_adapter(proposal, initial_scale = 1., target_accept_prob = 0.4),
-  variance_adapter(proposal)
+  scale_adapter(initial_scale = 1., target_accept_prob = 0.4),
+  variance_adapter()
 )
 ```
 


### PR DESCRIPTION
Some changes to improve user experience of `sample_chain` function and decrease side effects

- Copy initial state in `sample_chain` to avoid mutating argument.
- Change how adapters are initialize to no longer require passing in proposal, with this instead dealt with internally within `sample_chain` by passing in proposal to `initialize`, `update` and `finalize` method. This makes it easier to resuse adapters across proposals.