### PR TITLE
Use new argument names in codecov action

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,8 +41,8 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
#49 seems to have broken codecov workflow. `file` and `plugin` argument names have been deprecated in favour of `files` and `plugins` so seeing if updating these fixes.