### PR TITLE
Refactor Barker proposal as involution and correct sign

### DIFF
--- a/R/barker.R
+++ b/R/barker.R
@@ -31,8 +31,9 @@ sample_barker <- function(
   p_signs <- logistic_sigmoid((grad %@% scale_and_shape) * auxiliary)
   signs <- 2 * (sample_uniform(dim) < p_signs) - 1
   momentum <- signs * auxiliary
+  state$update(momentum = momentum)
   position <- state$position() + (scale_and_shape %@% momentum)
-  chain_state(position = position, momentum = momentum)
+  chain_state(position = position, momentum = -momentum)
 }
 
 #' Compute logarithm of Barker proposal density ratio.
@@ -50,11 +51,11 @@ log_density_ratio_barker <- function(
     scale_and_shape) {
   sum(
     log1p_exp(
-      state$momentum() * (
+      -state$momentum() * (
         state$gradient_log_density(target_distribution) %@% scale_and_shape
       )
     ) - log1p_exp(
-      proposed_state$momentum() * (
+      -proposed_state$momentum() * (
         proposed_state$gradient_log_density(target_distribution) %@% scale_and_shape
       )
     )


### PR DESCRIPTION
The current Barker proposal has a bug in the computation of the log proposal density ratio due to not symmetrically storing 'momentum' (product of sign and noise auxiliary variables) in current state (and negative in proposed state). This PR fixes this by reformulating proposal as corresponding to an involution on an augmented space:

Define joint target distribution on augmented space with $x \in \mathbb{R}^N$ and $v \in \mathbb{R}^N$ 

$$\bar{\pi}(\mathrm{d}x, \mathrm{d}v) = \pi(x) \mathrm{d}x ~\mu(v) \prod_{n=1}^N \mathsf{sigmoid}\left(v_n (\partial_n (\log \pi)(x) S)\right) \mathrm{d}v$$

with $\mu$ a symmetric density with respect to Lebesgue measure on $\mathbb{R}^N$ such that $\mu(v) = \mu(-v)$, and $S \in \mathbb{R}^{N\times N}$ is a pre-conditioner / shape matrix.

Let $\phi$ be a (volume preserving) involution on joint space defined by

$$\phi(x, v) = (x + S v, -v)$$

Then Barker proposal corresponds to alternating

1. Performing Gibbs step by sampling $v$ independently given current $x$
2. Proposing $(x', v') = \phi(x, v)$ and accepting with probability
```math
\begin{aligned}
\min\left(1, \frac{\bar{\pi}(\mathrm{d}x', \mathrm{d}v')}{\bar{\pi}(\mathrm{d}x, \mathrm{d}v)}\right)
&= \min\left( 1, \frac{\pi(x')\prod_{n=1}^N \mathsf{sigmoid}\left(v_n' (\partial (\log \pi)(x')S)_n\right)}{\pi(x) \prod_{n=1}^N \mathsf{sigmoid}\left(v_n (\partial (\log \pi)(x) S)_n\right)} \right) \\
&= \min\left( 1, \frac{\pi(x + Sv)\prod_{n=1}^N \mathsf{sigmoid}\left(-v_n (\partial(\log \pi)(x + Sv)S)_n\right)}{\pi(x) \prod_{n=1}^N \mathsf{sigmoid}\left(v_n (\partial (\log \pi)(x) S)_n\right)} \right) \\
&= \min\left( 1, \frac{\pi(x + Sv) \prod_{n=1}^N \left( 1 + \exp\left(-v_n (\partial (\log \pi)(x) S)_n\right)\right)}{\pi(x) \prod_{n=1}^N \left(1 + \exp\left(v_n (\partial (\log \pi)(x + Sv))_n\right)\right)} \right)
\end{aligned}
```