### PR TITLE
Use adapter settings in vignette to match Livingstone and Zanella (2022) paper

### DIFF
--- a/R/adaptation.R
+++ b/R/adaptation.R
@@ -291,7 +291,7 @@ variance_shape_adapter <- function(kappa = 1) {
 #' restatement of method proposed in Haario et al. (2001).
 #'
 #' Requires `ramcmc` package to be installed for access to efficient rank-1
-#' Cholesky update function [ramcmc::chol_update()].
+#' Cholesky update function `ramcmc::chol_update`.
 #'
 #' @param kappa Decay rate exponent in `[0.5, 1]` for adaptation learning rate.
 #'  Value of 1 (default) corresponds to computing empirical covariance matrix.

--- a/R/adaptation.R
+++ b/R/adaptation.R
@@ -61,6 +61,8 @@ scale_adapter <- function(
 #'
 #' @param kappa Decay rate exponent in `[0.5, 1]` for adaptation learning rate.
 #'
+#' @references Andrieu, C., & Thoms, J. (2008). A tutorial on adaptive MCMC.
+#'   _Statistics and Computing_, 18, 343-373.
 #' @references Robbins, H., & Monro, S. (1951). A stochastic approximation
 #'   method. _The Annals of Mathematical Statistics_, 400-407.
 #'

--- a/R/chains.R
+++ b/R/chains.R
@@ -13,11 +13,11 @@
 #' @param n_main_iteration Number of main (non-adaptive) chain iterations to
 #'   run.
 #' @param adapters List of adapters to tune proposal parameters during warm-up.
-#'   Defaults to using list with instances of [dual_averaging_scale_adapter()]
-#'   and [covariance_shape_adapter()], corresponding to respectively, adapting
-#'   the scale to coerce the average acceptance rate to a target value using a
-#'   dual-averaging algorithm, and adapting the shape to an estimate of the
-#'   covariance of the target distribution.
+#'   Defaults to using list with instances of [scale_adapter()] and
+#'   [shape_adapter()], corresponding to respectively, adapting the scale to
+#'   coerce the average acceptance rate to a target value using a dual-averaging
+#'   algorithm, and adapting the shape to an estimate of the covariance of the
+#'   target distribution.
 #' @param trace_function Function which given current chain state outputs list
 #'   of variables to trace on each main (non-adaptive) chain iteration.
 #' @param show_progress_bar Whether to show progress bars during sampling.
@@ -68,7 +68,7 @@ sample_chain <- function(
     initial_state,
     n_warm_up_iteration,
     n_main_iteration,
-    adapters = list(dual_averaging_scale_adapter(), covariance_shape_adapter()),
+    adapters = list(scale_adapter(), shape_adapter()),
     trace_function = NULL,
     show_progress_bar = TRUE,
     trace_warm_up = FALSE) {

--- a/man/covariance_shape_adapter.Rd
+++ b/man/covariance_shape_adapter.Rd
@@ -31,7 +31,7 @@ restatement of method proposed in Haario et al. (2001).
 }
 \details{
 Requires \code{ramcmc} package to be installed for access to efficient rank-1
-Cholesky update function \code{\link[ramcmc:chol_update]{ramcmc::chol_update()}}.
+Cholesky update function \code{ramcmc::chol_update}.
 }
 \examples{
 target_distribution <- list(

--- a/man/sample_chain.Rd
+++ b/man/sample_chain.Rd
@@ -10,7 +10,7 @@ sample_chain(
   initial_state,
   n_warm_up_iteration,
   n_main_iteration,
-  adapters = list(dual_averaging_scale_adapter(), covariance_shape_adapter()),
+  adapters = list(scale_adapter(), shape_adapter()),
   trace_function = NULL,
   show_progress_bar = TRUE,
   trace_warm_up = FALSE
@@ -43,11 +43,11 @@ run.}
 run.}
 
 \item{adapters}{List of adapters to tune proposal parameters during warm-up.
-Defaults to using list with instances of \code{\link[=dual_averaging_scale_adapter]{dual_averaging_scale_adapter()}}
-and \code{\link[=covariance_shape_adapter]{covariance_shape_adapter()}}, corresponding to respectively, adapting
-the scale to coerce the average acceptance rate to a target value using a
-dual-averaging algorithm, and adapting the shape to an estimate of the
-covariance of the target distribution.}
+Defaults to using list with instances of \code{\link[=scale_adapter]{scale_adapter()}} and
+\code{\link[=shape_adapter]{shape_adapter()}}, corresponding to respectively, adapting the scale to
+coerce the average acceptance rate to a target value using a dual-averaging
+algorithm, and adapting the shape to an estimate of the covariance of the
+target distribution.}
 
 \item{trace_function}{Function which given current chain state outputs list
 of variables to trace on each main (non-adaptive) chain iteration.}

--- a/man/stochastic_approximation_scale_adapter.Rd
+++ b/man/stochastic_approximation_scale_adapter.Rd
@@ -50,6 +50,9 @@ adapter <- stochastic_approximation_scale_adapter(
 adapter$initialize(proposal, chain_state(c(0, 0)))
 }
 \references{
+Andrieu, C., & Thoms, J. (2008). A tutorial on adaptive MCMC.
+\emph{Statistics and Computing}, 18, 343-373.
+
 Robbins, H., & Monro, S. (1951). A stochastic approximation
 method. \emph{The Annals of Mathematical Statistics}, 400-407.
 }

--- a/vignettes/barker-proposal.Rmd
+++ b/vignettes/barker-proposal.Rmd
@@ -74,17 +74,19 @@ Below we instantiate a list of adapters to
 ```{r}
 adapters <- list(
   scale_adapter(
+    algorithm = "stochastic_approximation",
     initial_scale = dimension^(-1 / 6),
-    target_accept_prob = 0.574
+    target_accept_prob = 0.574,
+    kappa = 0.6
   ),
-  shape_adapter("variance")
+  shape_adapter(type = "variance", kappa = 0.6)
 )
 ```
 
 Here we set the initial scale to $\mathcal{O}(\text{dimension}^{-\frac{1}{6}})$ 
 and the target acceptance probability to 0.574 following the guidelines in @vogrinc2023optimal.
 This is equivalent to the default behaviour when not specifying the `initial_scale` and `target_accept_prob` arguments, in which case proposal and dimension dependent values following the guidelines in @vogrinc2023optimal will be used. 
-Both adapters have an optional `kappa` argument which can be used to set the decay rate exponent for the adaptation learning rate. We leave this as the default value of 0.6 (following the recommendation in @livingstone2022barker) in both cases.
+Both adapters have an optional `kappa` argument which can be used to set the decay rate exponent for the adaptation learning rate. We set this to 0.6, following the recommendation in @livingstone2022barker, in both cases.
 
 The adapter updates will be applied only during an initial set of 'warm-up' chain iterations,
 with the proposal parameters remaining fixed to their final adapted values during a subsequent
@@ -199,7 +201,7 @@ cat(
 
 To sample a chain using a Langevin proposal, we can simple use `langevin_proposal` in place of `baker_proposal`.
 
-Here we create a new set of adapters using the default arguments to `scale_adapter` which will set the target acceptance rate to the Langevin proposal optimal value of 0.574 following the results in @roberts2001optimal.
+Here we create a new set of adapters using the default `target_accept_prob` argument to `scale_adapter` which will set the target acceptance rate to the Langevin proposal optimal value of 0.574 following the results in @roberts2001optimal.
 
 ```{r}
 mala_results <- sample_chain(
@@ -208,7 +210,10 @@ mala_results <- sample_chain(
   initial_state = initial_state,
   n_warm_up_iteration = n_warm_up_iteration,
   n_main_iteration = n_main_iteration,
-  adapters = list(scale_adapter(), shape_adapter("variance")),
+  adapters = list(
+    scale_adapter(algorithm = "stochastic_approximation", kappa = 0.6),
+    shape_adapter(type = "variance", kappa = 0.6)
+  ),
   trace_warm_up = TRUE
 )
 ```


### PR DESCRIPTION
Reverts changes to Barker proposal vignette output arising from changes to default adaptation settings in #62, by explicitly setting adaptation algorithm variant and control parameters to match Livingstone and Zanella (2022) experiments vignette is based on. Most importantly, the `kappa` learning rate exponent parameter for the variance based shape adaptation is fixed to 0.6 rather than its new default of 1 (which corresponds to using empirical variance estimates). A value of `kappa = 1`, by equally weighting all samples during warm-up, can be strongly affected by the initial chain state. As we initialise chain to samples from a dispersed $\mathsf{normal}(0, 10)$ distribution, this leads to an initial transient before converging to target distribution which disproportionately effects variance estimates.

Also fixes some minor issues introduced in #62, namely using cross reference syntax to refer to a function `ramcmc::chol_update` (which produces a warning as function is undocumented), adding a missing reference to Andrieu and Thoms (2008) and using the wrapper adapter functions in default `adapters` argument to `sample_chains` rather than underlying variant specific functions to avoid specifying defaults in multiple places.