### PR TITLE
Fix linting workflow and filter paths triggering Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,34 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .Rbuildignore
+      - .github/workflows/R-CMD-check.yaml
+      - DESCRIPTION
+      - LICENSE
+      - NAMESPACE
+      - NEWS.md
+      - R/**
+      - man/**
+      - tests/**
+      - vignettes/**
+
   pull_request:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .Rbuildignore
+      - .github/workflows/R-CMD-check.yaml
+      - DESCRIPTION
+      - LICENSE
+      - NAMESPACE
+      - NEWS.md
+      - R/**
+      - man/**
+      - tests/**
+      - vignettes/**
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,21 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .lintr
+      - .github/workflows/lint.yaml
+      - R/**
+      - tests/**
   pull_request:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .lintr
+      - .github/workflows/lint.yaml
+      - R/**
+      - tests/**
 
 name: lint
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, github::roualdes/bridgestan/R@v2.5.0, local::.
+          extra-packages: any::lintr, any::cyclocomp, github::roualdes/bridgestan/R@v2.5.0, local::.
           needs: lint
 
       - name: Lint

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,41 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .github/workflows/pkgdown.yaml
+      - .github/CONTRIBUTING.md
+      - _pkgdown.yml
+      - CODE_OF_CONDUCT.md
+      - DESCRIPTION
+      - LICENSE
+      - LICENSE.md
+      - NAMESPACE
+      - NEWS.md
+      - README.md
+      - README.Rmd
+      - R/**
+      - man/**
+      - vignettes/**
   pull_request:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .github/workflows/pkgdown.yaml
+      - .github/CONTRIBUTING.md
+      - _pkgdown.yml
+      - CODE_OF_CONDUCT.md
+      - DESCRIPTION
+      - LICENSE
+      - LICENSE.md
+      - NAMESPACE
+      - NEWS.md
+      - README.md
+      - README.Rmd
+      - R/**
+      - man/**
+      - vignettes/**
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,21 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .github/workflows/test-coverage.yaml
+      - DESCRIPTION
+      - R/**
+      - tests/**
   pull_request:
-    branches: [main, master]
+    branches:
+      - main
+    paths:
+      - .github/workflows/test-coverage.yaml
+      - DESCRIPTION
+      - R/**
+      - tests/**
 
 name: test-coverage
 

--- a/R/barker.R
+++ b/R/barker.R
@@ -178,7 +178,7 @@ bimodal_barker_proposal <- function(
     shape = NULL,
     sample_uniform = stats::runif) {
   sample_bimodal <- function(dimension) {
-    return(
+    (
       sample(c(-1, 1), dimension, TRUE) * sqrt(1 - sigma^2) +
         stats::rnorm(dimension) * sigma
     )

--- a/R/chains.R
+++ b/R/chains.R
@@ -177,15 +177,13 @@ get_progress_bar <- function(use_progress_bar, n_iteration, label) {
     "%s :percent |:bar| :current/:total [:elapsed<:eta] :tick_rate it/s"
   )
   if (use_progress_bar) {
-    return(
-      progress::progress_bar$new(
-        format = sprintf(progress_bar_format, label),
-        total = n_iteration,
-        clear = FALSE
-      )
+    progress::progress_bar$new(
+      format = sprintf(progress_bar_format, label),
+      total = n_iteration,
+      clear = FALSE
     )
   } else {
-    return(NULL)
+    NULL
   }
 }
 

--- a/R/proposal.R
+++ b/R/proposal.R
@@ -5,11 +5,11 @@ get_shape_matrix <- function(scale, shape) {
   if (is.null(scale) && is.null(shape)) {
     stop("One of scale and shape parameters must be set")
   } else if (is.null(scale)) {
-    return(shape)
+    shape
   } else if (is.null(shape)) {
-    return(scale)
+    scale
   } else {
-    return(shape * scale)
+    shape * scale
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,13 +59,13 @@ is_non_scalar_vector <- function(obj) {
 #' @return Result of matrix vector multiplication of `left` and `right`.
 `%@%` <- function(left, right) {
   if (is.null(dim(left)) && is.null(dim(right))) {
-    return(left * right)
+    left * right
   } else if ((length(left) == 1 && length(right) == 1)) {
-    return(drop(left * right))
+    drop(left * right)
   } else if (is.matrix(left) && is_non_scalar_vector(right)) {
-    return(Matrix::drop(left %*% right))
+    Matrix::drop(left %*% right)
   } else if (is_non_scalar_vector(left) && is.matrix(right)) {
-    return(Matrix::drop(Matrix::t(right) %*% left))
+    Matrix::drop(Matrix::t(right) %*% left)
   } else {
     stop(
       paste0(

--- a/vignettes/adjusting-noise-distribution.Rmd
+++ b/vignettes/adjusting-noise-distribution.Rmd
@@ -60,7 +60,7 @@ with two equally-weighted normal components with means $\pm (1 - \sigma^2)$ and 
 ```{r}
 sample_bimodal <- function(dimension) {
   sigma <- 0.1
-  return(
+  (
     sample(c(-1, 1), dimension, TRUE) * sqrt(1 - sigma^2) +
       stats::rnorm(dimension) * sigma
   )


### PR DESCRIPTION
Fixes linting workflow which appears to [have broken ](https://github.com/UCL/rmcmc/actions/runs/13372971683)with [changes in v3.2.0 of `lintr`](https://github.com/r-lib/lintr/releases/tag/v3.2.0) which downgraded `cyclocomp` from an `Import` to `Suggests` dependency, meaning `cyclocomp` needs to be installed explicitly.

Also uses `paths` filter on Actions workflows to limit when runs are triggered to when changes are made to files for which the workflow is relevant.