### PR TITLE
Simplify logic in `sample_chain` by factoring out functions

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,7 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(88L),
     object_length_linter = object_length_linter(length=50L),
-    cyclocomp_linter = cyclocomp_linter(complexity_limit = 25L)
+    cyclocomp_linter = cyclocomp_linter(complexity_limit = 15L)
   )
 encoding: "UTF-8"
 exclusions: list(

--- a/R/chains.R
+++ b/R/chains.R
@@ -104,7 +104,7 @@ sample_chain <- function(
     trace_warm_up = FALSE) {
   progress_available <- requireNamespace("progress", quietly = TRUE)
   use_progress_bar <- progress_available && show_progress_bar
-  state <- check_and_process_initial_state(initial_state)
+  initial_state <- check_and_process_initial_state(initial_state)
   target_distribution <- check_and_process_target_distribution(
     target_distribution
   )
@@ -113,7 +113,7 @@ sample_chain <- function(
   warm_up_results <- chain_loop(
     stage_name = "Warm-up",
     n_iteration = n_warm_up_iteration,
-    state = state,
+    state = initial_state,
     target_distribution = target_distribution,
     proposal = proposal,
     adapters = adapters,
@@ -122,11 +122,10 @@ sample_chain <- function(
     trace_function = trace_function,
     statistic_names = statistic_names
   )
-  state <- warm_up_results$final_state
   main_results <- chain_loop(
     stage_name = "Main",
     n_iteration = n_main_iteration,
-    state = state,
+    state = warm_up_results$final_state,
     target_distribution = target_distribution,
     proposal = proposal,
     adapters = NULL,

--- a/R/chains.R
+++ b/R/chains.R
@@ -104,13 +104,7 @@ sample_chain <- function(
     trace_warm_up = FALSE) {
   progress_available <- requireNamespace("progress", quietly = TRUE)
   use_progress_bar <- progress_available && show_progress_bar
-  if (is.vector(initial_state) && is.atomic(initial_state)) {
-    state <- chain_state(initial_state)
-  } else if (is.vector(initial_state) && "position" %in% names(initial_state)) {
-    state <- initial_state$copy()
-  } else {
-    stop("initial_state must be a vector or list with an entry named position.")
-  }
+  state <- check_and_process_initial_state(initial_state)
   if (inherits(target_distribution, "formula")) {
     target_distribution <- target_distribution_from_log_density_formula(
       target_distribution
@@ -160,6 +154,16 @@ sample_chain <- function(
     return(combine_stage_results(warm_up_results, main_results))
   } else {
     return(main_results)
+  }
+}
+
+check_and_process_initial_state <- function(initial_state) {
+  if (is.vector(initial_state) && is.atomic(initial_state)) {
+    chain_state(initial_state)
+  } else if (is.vector(initial_state) && "position" %in% names(initial_state)) {
+    initial_state$copy()
+  } else {
+    stop("initial_state must be a vector or list with an entry named position.")
   }
 }
 


### PR DESCRIPTION
Reduces complexity of `sample_chain` and (internal) `chain_loop` functions by factoring out some self-contained functionality into utility functions and simplifying threading of chain state through calls. Also reduces complexity limit checked for in linting to previous default of 15.