### PR TITLE
Update to latest version of BridgeStan in workflows + update pre-commit config

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, github::roualdes/bridgestan/R@v2.5.0
+          extra-packages: any::rcmdcheck, github::roualdes/bridgestan/R@v2.6.2
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,8 +68,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, github::roualdes/bridgestan/R@v2.6.2
-          needs: check
+          needs: |
+            bridgestan
+            check
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, any::cyclocomp, github::roualdes/bridgestan/R@v2.5.0, local::.
+          extra-packages: any::lintr, any::cyclocomp, github::roualdes/bridgestan/R@v2.6.2, local::.
           needs: lint
 
       - name: Lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, any::cyclocomp, github::roualdes/bridgestan/R@v2.6.2, local::.
+          extra-packages: local::.
           needs: lint
 
       - name: Lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,9 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: local::.
-          needs: lint
+          needs: |
+            bridgestan
+            lint
 
       - name: Lint
         run: lintr::lint_package()

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, github::roualdes/bridgestan/R@v2.5.0, local::.
+          extra-packages: any::pkgdown, github::roualdes/bridgestan/R@v2.6.2, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -66,8 +66,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, github::roualdes/bridgestan/R@v2.6.2, local::.
-          needs: website
+          extra-packages: local::.
+          needs: |
+            bridgestan
+            website
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: any::sessioninfo
           needs: |
+            bridgestan
             lint
             style
             website

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,28 +13,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: local::.
-          needs: |
-            bridgestan
-            lint
-            style
-            website
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - name: Install Python dependencies
-        run: python -m pip install pre-commit
-
       - name: Run pre-commit
-        run: pre-commit run --all-files --color always --verbose
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::styler, github::roualdes/bridgestan/R@v2.5.0, local::.
+          extra-packages: any::pkgdown, any::styler, github::roualdes/bridgestan/R@v2.6.2, local::.
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,6 +24,7 @@ jobs:
           extra-packages: local::.
           needs: |
             bridgestan
+            lint
             style
             website
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,11 @@ jobs:
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::styler, github::roualdes/bridgestan/R@v2.6.2, local::.
+          extra-packages: local::.
+          needs: |
+            bridgestan
+            style
+            website
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          packages: any::sessioninfo
           needs: |
             lint
             style

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,6 +18,14 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: |
+            lint
+            style
+            website
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -37,8 +37,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2, github::roualdes/bridgestan/R@v2.6.2
-          needs: coverage
+          needs: |
+            bridgestan
+            coverage
 
       - name: Test coverage
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2, github::roualdes/bridgestan/R@v2.5.0
+          extra-packages: any::covr, any::xml2, github::roualdes/bridgestan/R@v2.6.2
           needs: coverage
 
       - name: Test coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3
+    rev: v0.4.3.9013
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,10 @@ repos:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
     -   id: roxygenize
-        # roxygen requires loading pkg -> add dependencies from DESCRIPTION
-        additional_dependencies:
-        -    Matrix
-        -    rlang
-        -    withr
     -   id: use-tidy-description
-    # disable lintr hook pending resolution of
-    # https://github.com/lorenzwalthert/precommit/issues/440
-    # -   id: lintr
+    -   id: lintr
+        args: [--warn_only]
+        verbose: true
     -   id: readme-rmd-rendered
     -   id: parsable-R
     -   id: no-browser-statement

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,6 @@ repos:
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
     -   id: roxygenize
     -   id: use-tidy-description
-    -   id: lintr
-        args: [--warn_only]
-        verbose: true
     -   id: readme-rmd-rendered
     -   id: parsable-R
     -   id: no-browser-statement

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/Needs/bridgestan:
-    github::roualdes/bridgestan/R@v2.6.2
+    url::https://community.r-multiverse.org/src/contrib/bridgestan_2.6.2.tar.gz
 Config/Needs/check:
     any::rcmdcheck
 Config/Needs/coverage:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,20 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Config/Needs/bridgestan:
+    github::roualdes/bridgestan/R@v2.6.2
+Config/Needs/check:
+    any::rcmdcheck
+Config/Needs/coverage:
+     any::covr,
+     any::xml2
+Config/Needs/lint:
+    any::lintr,
+    any::cyclocomp
+Config/Needs/style:
+    any::styler
+Config/Needs/website:
+    any::pkgdown
 URL: https://github.com/UCL/rmcmc, http://github-pages.ucl.ac.uk/rmcmc/
 BugReports: https://github.com/UCL/rmcmc/issues
 Imports: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/Needs/bridgestan:
-    url::https://community.r-multiverse.org/src/contrib/bridgestan_2.6.2.tar.gz
+    bridgestan=url::https://community.r-multiverse.org/src/contrib/bridgestan_2.6.2.tar.gz
 Config/Needs/check:
     any::rcmdcheck
 Config/Needs/coverage:


### PR DESCRIPTION
Was hoping this would fix issue with installing `bridgestan` in Actions workflows on Ubuntu / MacOS runners (#92), but starting to look like this might be an upstream issue with `pak` / `pkg_depends`.

EDIT: As it looks like from https://github.com/r-lib/pak/issues/807 that the issue with installing `bridgestan` from GitHub repository is an upstream issue in `pak` / `r-zip` packages, this PR switches to instead installing `bridgestan` from a source package on `r-multiverse`. Also updates pre-commit config to latest version and after some attempts at renabling `lintr` hook, removes the commented out version of this as (i) causes errors due to need to explicitly install `cyclocomp` package, (ii) redudant given separate linting workflow.