### PR TITLE
Manually install and invoke pre-commit in Actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -32,5 +32,8 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install Python dependencies
+        run: python -m pip install pre-commit
+
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        run: pre-commit run --all-files --color always --verbose


### PR DESCRIPTION
The switch to using `pre-commit` Action in #91 is causing issues due to a bad interaction between the caching happening in that Action and the `setup-r-dependencies` step used to install the R dependencies, with subsequent runs from a restored cache complaining about the R packages having broken symlinks. This PR switches back to manually installing and running `pre-commit` which avoids using the cache.