### PR TITLE
Fix inclusion of generated quantities in Stan model output

### DIFF
--- a/R/bridges.R
+++ b/R/bridges.R
@@ -41,10 +41,14 @@ target_distribution_from_stan_model <- function(
   trace_function <- function(state) {
     position <- state$position()
     trace_values <- model$param_constrain(
-      position, include_transformed_parameters, include_generated_quantities, rng
+      position,
+      include_tp = include_transformed_parameters,
+      include_gq = include_generated_quantities,
+      rng = rng
     )
     names(trace_values) <- model$param_names(
-      include_gq = include_generated_quantities, include_tp = include_transformed_parameters
+      include_tp = include_transformed_parameters,
+      include_gq = include_generated_quantities
     )
     if (include_log_density) {
       trace_values["log_density"] <- model$log_density(position)

--- a/R/bridges.R
+++ b/R/bridges.R
@@ -8,6 +8,8 @@
 #'   in Stan model definition in values returned by trace function.
 #' @param include_transformed_parameters Whether to include transformed
 #'   parameters in Stan model definition in values returned by trace function.
+#' @param seed Seed to use for random number generator used to for any random numbers
+#'   generated as part of generated quantities block.
 #'
 #' @return A list with entries
 #' * `log_density`: A function to evaluate log density function for target

--- a/R/bridges.R
+++ b/R/bridges.R
@@ -33,13 +33,17 @@ target_distribution_from_stan_model <- function(
     model,
     include_log_density = TRUE,
     include_generated_quantities = FALSE,
-    include_transformed_parameters = FALSE) {
+    include_transformed_parameters = FALSE,
+    seed = 1234L) {
+  rng <- model$new_rng(seed)
   trace_function <- function(state) {
     position <- state$position()
     trace_values <- model$param_constrain(
-      position, include_transformed_parameters, include_generated_quantities
+      position, include_transformed_parameters, include_generated_quantities, rng
     )
-    names(trace_values) <- model$param_names()
+    names(trace_values) <- model$param_names(
+      include_gq = include_generated_quantities, include_tp = include_transformed_parameters
+    )
     if (include_log_density) {
       trace_values["log_density"] <- model$log_density(position)
     }
@@ -84,10 +88,18 @@ example_gaussian_stan_model <- function(n_data = 50, seed = 1234L) {
     real mu;
     real<lower=0> sigma;
   }
+  transformed parameters {
+    // Adding an arbitrary entry here to allow testing for inclusion of transformed
+    // parameters in output - not needed in practice
+    real log_sigma = log(sigma);
+  }
   model {
     mu ~ normal(0, 3);
     sigma ~ normal(0, 3);
     y ~ normal(mu, sigma);
+  }
+  generated quantities {
+    real y_pred = normal_rng(mu, sigma);
   }"
   withr::with_seed(seed, y <- stats::rnorm(n_data))
   data_string <- sprintf('{"N": %i, "y": [%s]}', n_data, toString(y))

--- a/man/target_distribution_from_stan_model.Rd
+++ b/man/target_distribution_from_stan_model.Rd
@@ -8,7 +8,8 @@ target_distribution_from_stan_model(
   model,
   include_log_density = TRUE,
   include_generated_quantities = FALSE,
-  include_transformed_parameters = FALSE
+  include_transformed_parameters = FALSE,
+  seed = 1234L
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ in Stan model definition in values returned by trace function.}
 
 \item{include_transformed_parameters}{Whether to include transformed
 parameters in Stan model definition in values returned by trace function.}
+
+\item{seed}{Seed to use for random number generator used to for any random numbers
+generated as part of generated quantities block.}
 }
 \value{
 A list with entries


### PR DESCRIPTION
Resolves #89 

Also updates tests to cover `include_generated_quantities=TRUE` and `include_transformed_parameters=TRUE` cases in `target_distribution_from_stan_model`.