### PR TITLE
Update to bridgestan v0.7.0 in workflows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/Needs/bridgestan:
-    bridgestan=url::https://community.r-multiverse.org/src/contrib/bridgestan_2.6.2.tar.gz
+    bridgestan=url::https://community.r-multiverse.org/src/contrib/bridgestan_2.7.0.tar.gz
 Config/Needs/check:
     any::rcmdcheck
 Config/Needs/coverage:


### PR DESCRIPTION
Because of r-lib/pak#807 we cannot use a `github` package reference for `bridgestan` so need to use an explicit URL pointing to a specific `r-multiverse` release. Unfortunately it seems that only artifacts for the latest release may be retained on `r-multiverse` as workflow runs triggered since release of new v0.7.0 version are failing to pick up previous v0.6.2 release although this may a function of [errors in `bridgestan`'s `r-multiverse` build](https://community.r-multiverse.org/bridgestan#checktable).