### PR TITLE
Add manual progress fallback when progress package unavailable

### DIFF
--- a/R/chains.R
+++ b/R/chains.R
@@ -303,8 +303,10 @@ chain_loop <- function(
   }
   # Ensure progress bar shows completed in cases tick_amount not a factor of
   # n_iteration
-  if (!is.null(progress_bar) && !progress_bar$finished) progress_bar$update(1)
-  if (show_progress_bar && !progress_available && n_iteration > 0 && (n_iteration %% tick_amount != 0)) {
+  progress_unfinished <- n_iteration > 0 && (n_iteration %% tick_amount != 0)
+  if (!is.null(progress_bar) && progress_unfinished) {
+    progress_bar$update(1)
+  } else if (show_progress_bar && !progress_available && progress_unfinished) {
     elapsed <- proc.time()[["elapsed"]] - start_time
     message(sprintf(
       "%s: 100%% done (%d/%d iterations) | elapsed: %.1fs",

--- a/R/chains.R
+++ b/R/chains.R
@@ -56,8 +56,9 @@
 #'   coerce the average acceptance rate to a target value using a dual-averaging
 #'   algorithm, and adapting the shape to an estimate of the covariance of the
 #'   target distribution.
-#' @param show_progress_bar Whether to show progress bars during sampling.
-#'   Requires `progress` package to be installed to have an effect.
+#' @param show_progress_bar Whether to show progress bars during sampling. If the
+#'   `progress` package is installed, displays a progress bar; otherwise prints
+#'   periodic progress messages to the console.
 #' @param trace_warm_up Whether to record chain traces and adaptation /
 #'   transition statistics during (adaptive) warm-up iterations in addition to
 #'   (non-adaptive) main chain iterations.
@@ -103,8 +104,12 @@ sample_chain <- function(
   show_progress_bar = TRUE,
   trace_warm_up = FALSE
 ) {
-  progress_available <- requireNamespace("progress", quietly = TRUE)
-  use_progress_bar <- progress_available && show_progress_bar
+  progress_available <- is_package_available("progress")
+  if (show_progress_bar && !progress_available) {
+    message(
+      "progress package is not installed, so will print progress updates below."
+    )
+  }
   initial_state <- check_and_process_initial_state(initial_state)
   target_distribution <- check_and_process_target_distribution(
     target_distribution
@@ -118,7 +123,8 @@ sample_chain <- function(
     target_distribution = target_distribution,
     proposal = proposal,
     adapters = adapters,
-    use_progress_bar = use_progress_bar,
+    show_progress_bar = show_progress_bar,
+    progress_available = progress_available,
     record_traces_and_statistics = trace_warm_up,
     trace_function = trace_function,
     statistic_names = statistic_names
@@ -130,7 +136,8 @@ sample_chain <- function(
     target_distribution = target_distribution,
     proposal = proposal,
     adapters = NULL,
-    use_progress_bar = use_progress_bar,
+    show_progress_bar = show_progress_bar,
+    progress_available = progress_available,
     record_traces_and_statistics = TRUE,
     trace_function = trace_function,
     statistic_names = statistic_names
@@ -184,11 +191,13 @@ default_trace_function <- function(target_distribution) {
   }
 }
 
-get_progress_bar <- function(use_progress_bar, n_iteration, label) {
+is_package_available <- function(pkg) requireNamespace(pkg, quietly = TRUE)
+
+get_progress_bar <- function(show_progress_bar, progress_available, n_iteration, label) {
   progress_bar_format <- (
     "%s :percent |:bar| :current/:total [:elapsed<:eta] :tick_rate it/s"
   )
-  if (use_progress_bar) {
+  if (show_progress_bar && progress_available) {
     progress::progress_bar$new(
       format = sprintf(progress_bar_format, label),
       total = n_iteration,
@@ -244,12 +253,15 @@ chain_loop <- function(
   target_distribution,
   proposal,
   adapters,
-  use_progress_bar,
+  show_progress_bar,
+  progress_available,
   record_traces_and_statistics,
   trace_function,
   statistic_names
 ) {
-  progress_bar <- get_progress_bar(use_progress_bar, n_iteration, stage_name)
+  progress_bar <- get_progress_bar(
+    show_progress_bar, progress_available, n_iteration, stage_name
+  )
   # Only show 10% increments in progress bar to avoid progress bar updates being
   # a bottleneck when chain iteration rate is high
   tick_amount <- max(n_iteration %/% 10, 1)
@@ -261,6 +273,7 @@ chain_loop <- function(
     traces <- NULL
     statistics <- NULL
   }
+  start_time <- proc.time()[["elapsed"]]
   for (chain_iteration in seq_len(n_iteration)) {
     state_and_statistics <- sample_metropolis_hastings(
       state, target_distribution, proposal
@@ -276,11 +289,28 @@ chain_loop <- function(
     }
     if (!is.null(progress_bar) && (chain_iteration %% tick_amount == 0)) {
       progress_bar$tick(tick_amount)
+    } else if (   # fallback: manual progress updates
+      show_progress_bar && !progress_available &&
+      (chain_iteration %% tick_amount == 0)
+    ) {
+      elapsed <- proc.time()[["elapsed"]] - start_time
+      pct <- round(100 * chain_iteration / n_iteration)
+      message(sprintf(
+        "%s: %d%% done (%d/%d iterations) | elapsed: %.1fs",
+        stage_name, pct, chain_iteration, n_iteration, elapsed
+      ))
     }
   }
   # Ensure progress bar shows completed in cases tick_amount not a factor of
   # n_iteration
   if (!is.null(progress_bar) && !progress_bar$finished) progress_bar$update(1)
+  if (show_progress_bar && !progress_available && n_iteration > 0 && (n_iteration %% tick_amount != 0)) {
+    elapsed <- proc.time()[["elapsed"]] - start_time
+    message(sprintf(
+      "%s: 100%% done (%d/%d iterations) | elapsed: %.1fs",
+      stage_name, n_iteration, n_iteration, elapsed
+    ))
+  }
   finalize_adapters(adapters, proposal)
   list(final_state = state, traces = traces, statistics = statistics)
 }

--- a/R/chains.R
+++ b/R/chains.R
@@ -287,12 +287,10 @@ chain_loop <- function(
         c(state_and_statistics$statistics, adapter_states)
       )
     }
-    if (!is.null(progress_bar) && (chain_iteration %% tick_amount == 0)) {
+    do_tick <- chain_iteration %% tick_amount == 0
+    if (!is.null(progress_bar) && do_tick) {
       progress_bar$tick(tick_amount)
-    } else if (   # fallback: manual progress updates
-      show_progress_bar && !progress_available &&
-      (chain_iteration %% tick_amount == 0)
-    ) {
+    } else if (show_progress_bar && do_tick) {  # fallback progress updates
       elapsed <- proc.time()[["elapsed"]] - start_time
       pct <- round(100 * chain_iteration / n_iteration)
       message(sprintf(

--- a/R/chains.R
+++ b/R/chains.R
@@ -104,7 +104,7 @@ sample_chain <- function(
   show_progress_bar = TRUE,
   trace_warm_up = FALSE
 ) {
-  progress_available <- is_package_available("progress")
+  progress_available <- is_progress_package_available()
   if (show_progress_bar && !progress_available) {
     message(
       "progress package is not installed, so will print progress updates below."
@@ -192,6 +192,19 @@ default_trace_function <- function(target_distribution) {
 }
 
 is_package_available <- function(pkg) requireNamespace(pkg, quietly = TRUE)
+
+is_progress_package_available <- function() is_package_available("progress")
+
+print_fallback_progress <- function(
+  stage_name, chain_iteration, n_iteration, start_time
+) {
+  elapsed <- proc.time()[["elapsed"]] - start_time
+  pct <- round(100 * chain_iteration / n_iteration)
+  message(sprintf(
+    "%s: %d%% done (%d/%d iterations) | elapsed: %.1fs",
+    stage_name, pct, chain_iteration, n_iteration, elapsed
+  ))
+}
 
 get_progress_bar <- function(
   show_progress_bar, progress_available, n_iteration, label
@@ -292,13 +305,10 @@ chain_loop <- function(
     do_tick <- chain_iteration %% tick_amount == 0
     if (!is.null(progress_bar) && do_tick) {
       progress_bar$tick(tick_amount)
-    } else if (show_progress_bar && do_tick) {  # fallback progress updates
-      elapsed <- proc.time()[["elapsed"]] - start_time
-      pct <- round(100 * chain_iteration / n_iteration)
-      message(sprintf(
-        "%s: %d%% done (%d/%d iterations) | elapsed: %.1fs",
-        stage_name, pct, chain_iteration, n_iteration, elapsed
-      ))
+    } else if (show_progress_bar && do_tick) { # fallback progress updates
+      print_fallback_progress(
+        stage_name, chain_iteration, n_iteration, start_time
+      )
     }
   }
   # Ensure progress bar shows completed in cases tick_amount not a factor of
@@ -307,11 +317,7 @@ chain_loop <- function(
   if (!is.null(progress_bar) && progress_unfinished) {
     progress_bar$update(1)
   } else if (show_progress_bar && !progress_available && progress_unfinished) {
-    elapsed <- proc.time()[["elapsed"]] - start_time
-    message(sprintf(
-      "%s: 100%% done (%d/%d iterations) | elapsed: %.1fs",
-      stage_name, n_iteration, n_iteration, elapsed
-    ))
+    print_fallback_progress(stage_name, n_iteration, n_iteration, start_time)
   }
   finalize_adapters(adapters, proposal)
   list(final_state = state, traces = traces, statistics = statistics)

--- a/R/chains.R
+++ b/R/chains.R
@@ -316,7 +316,7 @@ chain_loop <- function(  # nolint: cyclocomp_linter
   progress_unfinished <- n_iteration > 0 && (n_iteration %% tick_amount != 0)
   if (!is.null(progress_bar) && progress_unfinished) {
     progress_bar$update(1)
-  } else if (show_progress_bar && !progress_available && progress_unfinished) {
+  } else if (show_progress_bar && progress_unfinished) {
     print_fallback_progress(stage_name, n_iteration, n_iteration, start_time)
   }
   finalize_adapters(adapters, proposal)

--- a/R/chains.R
+++ b/R/chains.R
@@ -261,7 +261,7 @@ finalize_adapters <- function(adapters, proposal) {
   invisible(adapters)
 }
 
-chain_loop <- function(
+chain_loop <- function(  # nolint: cyclocomp_linter
   stage_name,
   n_iteration,
   state,

--- a/R/chains.R
+++ b/R/chains.R
@@ -261,7 +261,8 @@ finalize_adapters <- function(adapters, proposal) {
   invisible(adapters)
 }
 
-chain_loop <- function(  # nolint: cyclocomp_linter
+chain_loop <- function(
+  # nolint: cyclocomp_linter
   stage_name,
   n_iteration,
   state,

--- a/R/chains.R
+++ b/R/chains.R
@@ -193,7 +193,9 @@ default_trace_function <- function(target_distribution) {
 
 is_package_available <- function(pkg) requireNamespace(pkg, quietly = TRUE)
 
-get_progress_bar <- function(show_progress_bar, progress_available, n_iteration, label) {
+get_progress_bar <- function(
+  show_progress_bar, progress_available, n_iteration, label
+) {
   progress_bar_format <- (
     "%s :percent |:bar| :current/:total [:elapsed<:eta] :tick_rate it/s"
   )

--- a/R/chains.R
+++ b/R/chains.R
@@ -261,8 +261,7 @@ finalize_adapters <- function(adapters, proposal) {
   invisible(adapters)
 }
 
-chain_loop <- function(
-  # nolint: cyclocomp_linter
+chain_loop <- function(  # nolint: cyclocomp_linter. styler: off
   stage_name,
   n_iteration,
   state,

--- a/man/sample_chain.Rd
+++ b/man/sample_chain.Rd
@@ -76,8 +76,9 @@ coerce the average acceptance rate to a target value using a dual-averaging
 algorithm, and adapting the shape to an estimate of the covariance of the
 target distribution.}
 
-\item{show_progress_bar}{Whether to show progress bars during sampling.
-Requires \code{progress} package to be installed to have an effect.}
+\item{show_progress_bar}{Whether to show progress bars during sampling. If the
+\code{progress} package is installed, displays a progress bar; otherwise prints
+periodic progress messages to the console.}
 
 \item{trace_warm_up}{Whether to record chain traces and adaptation /
 transition statistics during (adaptive) warm-up iterations in addition to

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -129,9 +129,9 @@ make_fallback_test_inputs <- function() {
 
 test_that("Manual progress fallback prints messages when progress unavailable", {
   inputs <- make_fallback_test_inputs()
-  # Simulate progress package being unavailable by mocking requireNamespace
+  # Simulate progress package being unavailable by mocking
   with_mocked_bindings(
-    is_package_available = function(pkg) FALSE,
+    is_progress_package_available = function() FALSE,
     .package = "rmcmc",
     {
       msgs <- capture_messages(
@@ -157,7 +157,7 @@ test_that("Manual progress fallback prints messages when progress unavailable", 
 test_that("No manual progress output when show_progress_bar is FALSE", {
   inputs <- make_fallback_test_inputs()
   with_mocked_bindings(
-    is_package_available = function(pkg) FALSE,
+    is_progress_package_available = function() FALSE,
     .package = "rmcmc",
     {
       expect_no_message(

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -1,5 +1,5 @@
 for (n_warm_up_iteration in c(0, 1, 10)) {
-  for (n_main_iteration in c(0, 1, 10)) {
+  for (n_main_iteration in c(0, 1, 10, 21)) {
     for (dimension in c(1, 2)) {
       for (trace_warm_up in c(TRUE, FALSE)) {
         for (show_progress_bar in c(TRUE, FALSE)) {

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -131,7 +131,7 @@ test_that("Manual progress fallback prints messages when progress unavailable", 
   inputs <- make_fallback_test_inputs()
   n_warm_up_iteration <- 10
   # use non-multiple of 10 to test finalisation of progress updates
-  n_main_iteration <- 11
+  n_main_iteration <- 21
   # Simulate progress package being unavailable by mocking
   with_mocked_bindings(
     is_progress_package_available = function() FALSE,
@@ -149,8 +149,16 @@ test_that("Manual progress fallback prints messages when progress unavailable", 
       )
     }
   )
-  # 1 upfront warning + 1 messages per iteration (warm-up + main)
-  expect_length(msgs, 1 + n_warm_up_iteration + n_main_iteration)
+  expected_n_progress_messages <- function(n_iteration) {
+    tick_amount <- max(n_iteration %/% 10, 1)
+    n_iteration %/% tick_amount + (n_iteration %% tick_amount != 0)
+  }
+  # 1 upfront warning + n_iteration dependent number of messages (warm-up + main)
+  expect_length(
+    msgs,
+    1 + expected_n_progress_messages(n_warm_up_iteration)
+      + expected_n_progress_messages(n_main_iteration)
+  )
   expect_true(any(grepl("progress package is not installed", msgs)))
   expect_true(any(grepl("10%", msgs)))
   expect_true(any(grepl("100%", msgs)))

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -129,6 +129,9 @@ make_fallback_test_inputs <- function() {
 
 test_that("Manual progress fallback prints messages when progress unavailable", {
   inputs <- make_fallback_test_inputs()
+  n_warm_up_iteration <- 10
+  # use non-multiple of 10 to test finalisation of progress updates
+  n_main_iteration <- 11
   # Simulate progress package being unavailable by mocking
   with_mocked_bindings(
     is_progress_package_available = function() FALSE,
@@ -138,17 +141,16 @@ test_that("Manual progress fallback prints messages when progress unavailable", 
         sample_chain(
           target_distribution = inputs$target_distribution,
           initial_state = inputs$position,
-          n_warm_up_iteration = 10,
-          n_main_iteration = 10,
+          n_warm_up_iteration = n_warm_up_iteration,
+          n_main_iteration = n_main_iteration,
           adapters = inputs$adapters,
           show_progress_bar = TRUE
         )
       )
     }
   )
-  # 1 upfront warning + 10 interval messages per stage (warm-up + main)
-  # = 1 + 10 + 10 = 21 messages total
-  expect_length(msgs, 21)
+  # 1 upfront warning + 1 messages per iteration (warm-up + main)
+  expect_length(msgs, 1 + n_warm_up_iteration + n_main_iteration)
   expect_true(any(grepl("progress package is not installed", msgs)))
   expect_true(any(grepl("10%", msgs)))
   expect_true(any(grepl("100%", msgs)))

--- a/tests/testthat/test-chains.R
+++ b/tests/testthat/test-chains.R
@@ -113,3 +113,63 @@ test_that("Sample chains with invalid target_distribution raises error", {
     "target_distribution"
   )
 })
+
+make_fallback_test_inputs <- function() {
+  target_distribution <- standard_normal_target_distribution()
+  adapters <- list(scale_adapter("stochastic_approximation", initial_scale = 1.))
+  withr::with_seed(default_seed(), {
+    position <- rnorm(2)
+  })
+  list(
+    target_distribution = target_distribution,
+    adapters = adapters,
+    position = position
+  )
+}
+
+test_that("Manual progress fallback prints messages when progress unavailable", {
+  inputs <- make_fallback_test_inputs()
+  # Simulate progress package being unavailable by mocking requireNamespace
+  with_mocked_bindings(
+    is_package_available = function(pkg) FALSE,
+    .package = "rmcmc",
+    {
+      msgs <- capture_messages(
+        sample_chain(
+          target_distribution = inputs$target_distribution,
+          initial_state = inputs$position,
+          n_warm_up_iteration = 10,
+          n_main_iteration = 10,
+          adapters = inputs$adapters,
+          show_progress_bar = TRUE
+        )
+      )
+    }
+  )
+  # 1 upfront warning + 10 interval messages per stage (warm-up + main)
+  # = 1 + 10 + 10 = 21 messages total
+  expect_length(msgs, 21)
+  expect_true(any(grepl("progress package is not installed", msgs)))
+  expect_true(any(grepl("10%", msgs)))
+  expect_true(any(grepl("100%", msgs)))
+})
+
+test_that("No manual progress output when show_progress_bar is FALSE", {
+  inputs <- make_fallback_test_inputs()
+  with_mocked_bindings(
+    is_package_available = function(pkg) FALSE,
+    .package = "rmcmc",
+    {
+      expect_no_message(
+        sample_chain(
+          target_distribution = inputs$target_distribution,
+          initial_state = inputs$position,
+          n_warm_up_iteration = 10,
+          n_main_iteration = 10,
+          adapters = inputs$adapters,
+          show_progress_bar = FALSE
+        )
+      )
+    }
+  )
+})


### PR DESCRIPTION
#29 

## Summary

Fixes the issue where calling `sample_chain()` with `show_progress_bar = TRUE` would silently produce no output if the `progress` package was not installed, making it appear to the user as though the program had halted — particularly problematic for long chains.

When `progress` is unavailable, the function now emits a one-time informational message and then prints percentage-based progress updates with elapsed time at 10% intervals to the console.

Example output when `progress` is not installed:
```
progress package is not installed, so will print progress updates below.
Warm-up: 10% done (1000/10000 iterations) | elapsed: 0.6s
Warm-up: 20% done (2000/10000 iterations) | elapsed: 1.2s
...
Warm-up: 100% done (10000/10000 iterations) | elapsed: 6.1s
Main: 10% done (1000/10000 iterations) | elapsed: 0.6s
...
Main: 100% done (10000/10000 iterations) | elapsed: 6.0s
```

## Changes

### `R/chains.R`

- **Add `is_package_available()` helper** — a thin wrapper around `requireNamespace()` that lives in the package namespace, making it mockable in tests via `with_mocked_bindings()`
- **Split `use_progress_bar` into two booleans** — `progress_available` (is the package installed?) and `show_progress_bar` (did the user ask for progress?) are now kept separate and passed independently through `sample_chain()` and `chain_loop()`, so the fallback path can distinguish between the two cases
- **Upfront warning in `sample_chain()`** — prints a one-time message when `show_progress_bar = TRUE` but `progress` is unavailable
- **Updated `get_progress_bar()` signature** — now accepts `show_progress_bar` and `progress_available` separately instead of the collapsed `use_progress_bar`
- **Fallback branch in `chain_loop()`** — added `else if` branch alongside the existing progress bar tick, printing a formatted `stage: X% done (n/total) | elapsed: Xs` message at every 10% interval using `proc.time()` (base R, no dependencies)
- **Post-loop 100% guard** — prints a final "100% done" message after the loop when `n_iteration` is not an exact multiple of `tick_amount`, ensuring completion is always reported
- **Updated `@param show_progress_bar` roxygen doc** — reflects that the parameter now controls both the progress bar (when `progress` is installed) and the fallback text output (when it is not)

### `tests/testthat/test-chains.R`

- **Add `make_fallback_test_inputs()` helper** — extracts shared setup (target distribution, adapters, initial position) used by both new tests into a single function to avoid duplication
- **New test: fallback messages are emitted** — mocks `is_package_available()` to return `FALSE`, captures all messages with `capture_messages()`, and asserts the correct total count, that the upfront warning is present, and that both 10% and 100% interval messages appear
- **New test: silent when `show_progress_bar = FALSE`** — same mock, asserts `expect_no_message()` confirming the fallback is correctly gated on the user's flag

## Testing

All existing tests continue to pass. The two new tests covering the fallback path and the silent-when-disabled case also pass.


## Notes

This PR is a draft / work in progress