### PR TITLE
Update bridgestan version as 2.7.0 no longer available on r-multiverse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/Needs/bridgestan:
-    bridgestan=url::https://community.r-multiverse.org/src/contrib/bridgestan_2.7.0.tar.gz
+    bridgestan=url::https://community.r-multiverse.org/src/contrib/bridgestan_2.9.0.tar.gz
 Config/Needs/check:
     any::rcmdcheck
 Config/Needs/coverage:


### PR DESCRIPTION
It looks like v2.7.0 build of bridgestan on r-multiverse is no longer available so point to latest version in `DESCRIPTION` file