### PR TITLE
Adding support for passing posteriordb posterior to `sample_chain`

### DIFF
--- a/R/bridges.R
+++ b/R/bridges.R
@@ -165,3 +165,27 @@ target_distribution_from_log_density_formula <- function(log_density_formula) {
     trace_function = trace_function
   )
 }
+
+#' Construct a target distribution from a posteriordb pdb_posterior object.
+#'
+#' @param posterior A `pdb_posterior` object created using `posterior` function
+#'    in `posteriordb` package and corresponding to one of the posteriors
+#'    defined in the posteriordb database.
+#'
+#' @returns A list with entries
+#' * `log_density`: A function to evaluate log density function for target
+#'   distribution given current position vector.
+#' * `value_and_gradient_log_density`: A function to evaluate value and gradient
+#'   of log density function for target distribution given current position
+#'   vector, returning as a list with entries `value` and `gradient`.
+#' @export
+#'
+#' @examples
+target_distribution_from_posteriordb <- function(posterior, seed=NULL) {
+  rlang::check_installed("bridgestan", reason = "to use this function")
+  rlang::check_installed("posteriordb", reason = "to use this function")
+  stan_path <- posteriordb::stan_code_file_path(posterior)
+  data_path <- posteriordb::data_file_path(posterior)
+  stan_model <- bridgestan::StanModel$new(stan_path, data_path, seed)
+  target_distribution_from_stan_model(stan_model)
+}

--- a/R/bridges.R
+++ b/R/bridges.R
@@ -181,7 +181,7 @@ target_distribution_from_log_density_formula <- function(log_density_formula) {
 #' @export
 #'
 #' @examples
-target_distribution_from_posteriordb <- function(posterior, seed=NULL) {
+target_distribution_from_posteriordb <- function(posterior, seed = NULL) {
   rlang::check_installed("bridgestan", reason = "to use this function")
   rlang::check_installed("posteriordb", reason = "to use this function")
   stan_path <- posteriordb::stan_code_file_path(posterior)

--- a/R/chains.R
+++ b/R/chains.R
@@ -187,6 +187,8 @@ check_and_process_target_distribution <- function(target_distribution) {
     target_distribution_from_log_density_formula(target_distribution)
   } else if (inherits(target_distribution, "StanModel")) {
     target_distribution_from_stan_model(target_distribution)
+  } else if (inherits(target_distribution, "pdb_posterior")) {
+    target_distribution_from_posteriordb(target_distribution)
   } else if (
     !is.list(target_distribution) ||
       !("log_density" %in% names(target_distribution))

--- a/tests/testthat/test-bridges.R
+++ b/tests/testthat/test-bridges.R
@@ -37,3 +37,13 @@ test_that("Using sample_chains with formula as target_distribution works", {
   expect_nrow(results$statistics, n_main_iteration)
   expect_ncol(results$statistics, 1)
 })
+
+test_that("Constructing target distribution from posteriordb posterior works", {
+  eight_schools_posterior <- posteriordb::posterior(
+    "eight_schools-eight_schools_centered"
+  )
+  target_distribution <- target_distribution_from_posteriordb(
+    eight_schools_posterior
+  )
+  check_target_distribution(target_distribution)
+})


### PR DESCRIPTION
Resolves #129 

Depends on specification of `initial_state` without requiring dimension to be known which is implemented in #139 so that should be merged first.#

TODO:
- [ ] Figure out why new test is slow to run
- [ ] Check seed default behaviour
- [ ] Add example usage